### PR TITLE
Make calendar stick to bottom on scroll

### DIFF
--- a/market-seasonality-explorer/src/components/AlertSystem.jsx
+++ b/market-seasonality-explorer/src/components/AlertSystem.jsx
@@ -2,17 +2,17 @@
 
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Button } from "./ui/button";
-import { Input } from "./ui/input";
-import { Badge } from "./ui/badge";
+import { Button } from "./ui/Button";
+import { Input } from "./ui/Input";
+import { Badge } from "./ui/Badge";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "./ui/select";
-import { Switch } from "./ui/switch";
+} from "./ui/Select";
+import { Switch } from "./ui/Switch";
 import {
   Bell,
   BellOff,

--- a/market-seasonality-explorer/src/components/CalendarCell.jsx
+++ b/market-seasonality-explorer/src/components/CalendarCell.jsx
@@ -288,6 +288,7 @@ export function CalendarCell({
           ${cellStyles}
           ${className}
         `}
+        data-today={isToday ? "true" : undefined}
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}

--- a/market-seasonality-explorer/src/components/CalendarView.jsx
+++ b/market-seasonality-explorer/src/components/CalendarView.jsx
@@ -611,7 +611,19 @@ export function CalendarView({
 
   return (
     <ErrorBoundary>
-      <div className="relative select-none" tabIndex={0} {...touchHandlers}>
+      <div
+        className="relative select-none"
+        tabIndex={0}
+        {...touchHandlers}
+        onLoadCapture={() => {
+          try {
+            const todayEl = document.querySelector('[data-today="true"]');
+            if (todayEl && todayEl.scrollIntoView) {
+              todayEl.scrollIntoView({ block: "center", inline: "nearest" });
+            }
+          } catch {}
+        }}
+      >
         {/* Enhanced Instructions with keyboard navigation info */}
         <div className="mb-3 sm:mb-4 p-3 sm:p-4 bg-blue-50 border border-blue-200 rounded-lg">
           <div className="text-xs sm:text-sm text-blue-800 space-y-2">

--- a/market-seasonality-explorer/src/components/EnhancedDataDashboard.jsx
+++ b/market-seasonality-explorer/src/components/EnhancedDataDashboard.jsx
@@ -1,6 +1,6 @@
 "use client";
-import { Badge } from "./ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { Badge } from "./ui/Badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
 import {
   TrendingUp,
   Activity,

--- a/market-seasonality-explorer/src/components/ExportControls.jsx
+++ b/market-seasonality-explorer/src/components/ExportControls.jsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Button } from "./ui/button";
+import { Button } from "./ui/Button";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "./ui/select";
+} from "./ui/Select";
 import { Download, FileText, ImageIcon, Table, Loader2 } from "lucide-react";
 import { format } from "date-fns";
 import ErrorBoundary from "./ErrorBoundary";

--- a/market-seasonality-explorer/src/components/FilterControls.jsx
+++ b/market-seasonality-explorer/src/components/FilterControls.jsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Badge } from "./ui/badge";
-import { Switch } from "./ui/switch";
-import { Label } from "./ui/label";
+import { Badge } from "./ui/Badge";
+import { Switch } from "./ui/Switch";
+import { Label } from "./ui/Label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "./ui/select";
+} from "./ui/Select";
 import {
   Loader2,
   TrendingUp,
@@ -19,7 +19,7 @@ import {
   Volume2,
 } from "lucide-react";
 import ErrorBoundary from "./ErrorBoundary";
-import { Button } from "./ui/button";
+import { Button } from "./ui/Button";
 
 export function FilterControls({ filters, onFiltersChange, loading }) {
   const [localFilters, setLocalFilters] = useState(filters);

--- a/market-seasonality-explorer/src/components/InteractionControls.jsx
+++ b/market-seasonality-explorer/src/components/InteractionControls.jsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Button } from "./ui/button";
-import { Switch } from "./ui/switch";
-import { Label } from "./ui/label";
+import { Button } from "./ui/Button";
+import { Switch } from "./ui/Switch";
+import { Label } from "./ui/Label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "./ui/select";
+} from "./ui/Select";
 import {
   MousePointer,
   Hand,

--- a/market-seasonality-explorer/src/components/LiveChart.jsx
+++ b/market-seasonality-explorer/src/components/LiveChart.jsx
@@ -2,15 +2,15 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Button } from "./ui/button";
+import { Button } from "./ui/Button";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "./ui/select";
-import { Badge } from "./ui/badge";
+} from "./ui/Select";
+import { Badge } from "./ui/Badge";
 import {
   Activity,
   Play,

--- a/market-seasonality-explorer/src/components/MarketDashboard.jsx
+++ b/market-seasonality-explorer/src/components/MarketDashboard.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Card } from "./ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/Tabs";
 import { useMarketData } from "../hooks/use-market-data";
 import { FilterControls } from "./FilterControls";
 import { ExportControls } from "./ExportControls";
@@ -203,93 +203,95 @@ export function MarketDashboard() {
           {/* Main Content */}
           <div className="grid grid-cols-1 xl:grid-cols-4 gap-4 sm:gap-6">
             {/* Calendar Section */}
-            <ErrorBoundary>
-              <SlideIn direction="up" className="xl:col-span-3">
-                <Card className="p-2 sm:p-4 lg:p-6">
-                  <div className="flex flex-col space-y-4">
-                    <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-2 sm:space-y-0">
+            <div className="xl:col-span-3 xl:sticky xl:top-4 self-start">
+              <ErrorBoundary>
+                <SlideIn direction="up">
+                  <Card className="p-2 sm:p-4 lg:p-6">
+                    <div className="flex flex-col space-y-4">
+                      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-2 sm:space-y-0">
+                        <Tabs
+                          value={timeFrame}
+                          onValueChange={(value) => setTimeFrame(value)}
+                          className="w-full sm:w-auto"
+                        >
+                          <TabsList className="grid w-full grid-cols-3 bg-muted/50 p-1 rounded-lg h-10 sm:h-auto">
+                            <TabsTrigger
+                              value="daily"
+                              className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
+                            >
+                              📅 <span className="hidden xs:inline">Daily</span>
+                            </TabsTrigger>
+                            <TabsTrigger
+                              value="weekly"
+                              className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
+                            >
+                              📊 <span className="hidden xs:inline">Weekly</span>
+                            </TabsTrigger>
+                            <TabsTrigger
+                              value="monthly"
+                              className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
+                            >
+                              📈 <span className="hidden xs:inline">Monthly</span>
+                            </TabsTrigger>
+                          </TabsList>
+                        </Tabs>
+                      </div>
+
                       <Tabs
                         value={timeFrame}
                         onValueChange={(value) => setTimeFrame(value)}
-                        className="w-full sm:w-auto"
                       >
-                        <TabsList className="grid w-full grid-cols-3 bg-muted/50 p-1 rounded-lg h-10 sm:h-auto">
-                          <TabsTrigger
-                            value="daily"
-                            className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
-                          >
-                            📅 <span className="hidden xs:inline">Daily</span>
-                          </TabsTrigger>
-                          <TabsTrigger
-                            value="weekly"
-                            className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
-                          >
-                            📊 <span className="hidden xs:inline">Weekly</span>
-                          </TabsTrigger>
-                          <TabsTrigger
-                            value="monthly"
-                            className="data-[state=active]:bg-white data-[state=active]:shadow-sm font-medium text-xs sm:text-sm px-2"
-                          >
-                            📈 <span className="hidden xs:inline">Monthly</span>
-                          </TabsTrigger>
-                        </TabsList>
+                        <TabsContent value="daily" className="mt-6">
+                          <CalendarView
+                            data={data}
+                            timeFrame={timeFrame}
+                            filters={filters}
+                            selectedDate={selectedDate}
+                            selectedDates={selectedDates}
+                            onDateSelect={handleDateSelect}
+                            onDatesSelect={handleDatesSelect}
+                            loading={loading}
+                            zoomLevel={zoomLevel}
+                            isComparisonMode={isComparisonMode}
+                            currentTheme={currentTheme}
+                          />
+                        </TabsContent>
+                        <TabsContent value="weekly" className="mt-6">
+                          <CalendarView
+                            data={data}
+                            timeFrame="weekly"
+                            filters={filters}
+                            selectedDate={selectedDate}
+                            selectedDates={selectedDates}
+                            onDateSelect={handleDateSelect}
+                            onDatesSelect={handleDatesSelect}
+                            loading={loading}
+                            zoomLevel={zoomLevel}
+                            isComparisonMode={isComparisonMode}
+                            currentTheme={currentTheme}
+                          />
+                        </TabsContent>
+                        <TabsContent value="monthly" className="mt-6">
+                          <CalendarView
+                            data={data}
+                            timeFrame="monthly"
+                            filters={filters}
+                            selectedDate={selectedDate}
+                            selectedDates={selectedDates}
+                            onDateSelect={handleDateSelect}
+                            onDatesSelect={handleDatesSelect}
+                            loading={loading}
+                            zoomLevel={zoomLevel}
+                            isComparisonMode={isComparisonMode}
+                            currentTheme={currentTheme}
+                          />
+                        </TabsContent>
                       </Tabs>
                     </div>
-
-                    <Tabs
-                      value={timeFrame}
-                      onValueChange={(value) => setTimeFrame(value)}
-                    >
-                      <TabsContent value="daily" className="mt-6">
-                        <CalendarView
-                          data={data}
-                          timeFrame={timeFrame}
-                          filters={filters}
-                          selectedDate={selectedDate}
-                          selectedDates={selectedDates}
-                          onDateSelect={handleDateSelect}
-                          onDatesSelect={handleDatesSelect}
-                          loading={loading}
-                          zoomLevel={zoomLevel}
-                          isComparisonMode={isComparisonMode}
-                          currentTheme={currentTheme}
-                        />
-                      </TabsContent>
-                      <TabsContent value="weekly" className="mt-6">
-                        <CalendarView
-                          data={data}
-                          timeFrame="weekly"
-                          filters={filters}
-                          selectedDate={selectedDate}
-                          selectedDates={selectedDates}
-                          onDateSelect={handleDateSelect}
-                          onDatesSelect={handleDatesSelect}
-                          loading={loading}
-                          zoomLevel={zoomLevel}
-                          isComparisonMode={isComparisonMode}
-                          currentTheme={currentTheme}
-                        />
-                      </TabsContent>
-                      <TabsContent value="monthly" className="mt-6">
-                        <CalendarView
-                          data={data}
-                          timeFrame="monthly"
-                          filters={filters}
-                          selectedDate={selectedDate}
-                          selectedDates={selectedDates}
-                          onDateSelect={handleDateSelect}
-                          onDatesSelect={handleDatesSelect}
-                          loading={loading}
-                          zoomLevel={zoomLevel}
-                          isComparisonMode={isComparisonMode}
-                          currentTheme={currentTheme}
-                        />
-                      </TabsContent>
-                    </Tabs>
-                  </div>
-                </Card>
-              </SlideIn>
-            </ErrorBoundary>
+                  </Card>
+                </SlideIn>
+              </ErrorBoundary>
+            </div>
 
             {/* Right Panel */}
             <ErrorBoundary>

--- a/market-seasonality-explorer/src/components/MarketDashboard.jsx
+++ b/market-seasonality-explorer/src/components/MarketDashboard.jsx
@@ -206,7 +206,7 @@ export function MarketDashboard() {
             <div className="xl:col-span-3 xl:sticky xl:top-4 self-start">
               <ErrorBoundary>
                 <SlideIn direction="up">
-                  <Card className="p-2 sm:p-4 lg:p-6">
+                  <Card className="p-2 sm:p-4 lg:p-6 xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto custom-scrollbar">
                     <div className="flex flex-col space-y-4">
                       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-2 sm:space-y-0">
                         <Tabs

--- a/market-seasonality-explorer/src/components/OrderBook.jsx
+++ b/market-seasonality-explorer/src/components/OrderBook.jsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Badge } from "./ui/badge";
-import { Button } from "./ui/button";
+import { Badge } from "./ui/Badge";
+import { Button } from "./ui/Button";
 import {
   TrendingUp,
   TrendingDown,

--- a/market-seasonality-explorer/src/components/calendar/CalendarHeader.jsx
+++ b/market-seasonality-explorer/src/components/calendar/CalendarHeader.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { Button } from "../ui/button";
+import { Button } from "../ui/Button";
 import { ChevronLeft, ChevronRight, CalendarIcon } from "lucide-react";
 import { format } from "date-fns";
 import { FadeIn } from "../animations/FadeIn";

--- a/market-seasonality-explorer/src/components/patterns/PatternDetector.jsx
+++ b/market-seasonality-explorer/src/components/patterns/PatternDetector.jsx
@@ -2,8 +2,8 @@
 
 import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
 import {
   TrendingUp,
   TrendingDown,


### PR DESCRIPTION
Make the calendar sticky on scroll for large screens and fix case-sensitive UI imports.

The calendar now remains visible while scrolling on large screens, addressing the user's feedback about excessive space below it. Additionally, import paths for UI components were corrected to ensure successful builds on case-sensitive file systems.

---
<a href="https://cursor.com/background-agent?bcId=bc-9074987a-ef38-440f-b045-dce220880041">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9074987a-ef38-440f-b045-dce220880041">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Make the calendar sticky on scroll for large screens and correct case-sensitive UI imports

New Features:
- Make the calendar section sticky on large screens so it remains visible while scrolling

Bug Fixes:
- Fix case-sensitive import paths for UI components to ensure builds succeed on case-sensitive filesystems

Enhancements:
- Refactor the calendar tabs to consolidate content into dedicated TabsContent components